### PR TITLE
MODCLUSTER-603: Clean old artifacts

### DIFF
--- a/windows/mod_proxy_cluster/build.bat
+++ b/windows/mod_proxy_cluster/build.bat
@@ -29,6 +29,9 @@ IF "%DISTRO%" equ "jboss" (
     IF NOT %ERRORLEVEL% == 0 ( exit 1 )
 )
 
+REM Remove old artifacts
+del /Q /F %WORKSPACE%\mod_proxy_cluster*.zip
+
 REM Note that some attributes cannot handle backslashes...
 SET WORKSPACE_POSSIX=%WORKSPACE:\=/%
 


### PR DESCRIPTION
We try to save as much time as possible, e.g. we don't re-download Apache Lounge httpd zip etc., so we must clean manually what is not needed any more. It is a trade off between clean workspace (delete workspace before build) and speed. The goal is to push the clone - build - smoke test cycle down to a handful of dozens of seconds.