### PR TITLE
Added libexpat to Git, changing cmake release builds and explicitly s…

### DIFF
--- a/windows/apr-util/build.bat
+++ b/windows/apr-util/build.bat
@@ -18,7 +18,8 @@ cd %WORKSPACE%\build-64
 REM Note that some attributes cannot handle backslashes...
 SET WORKSPACEPOSSIX=%WORKSPACE:\=/%
 
-cmake -G "NMake Makefiles" -DAPR_INCLUDE_DIR=%WORKSPACEPOSSIX%/apr/include/ ^
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
+-DAPR_INCLUDE_DIR=%WORKSPACEPOSSIX%/apr/include/ ^
 -DAPR_LIBRARIES=%WORKSPACEPOSSIX%/apr/lib/libapr-1.lib;%WORKSPACEPOSSIX%/apr/lib/libaprapp-1.lib ^
 -DOPENSSL_ROOT_DIR=%WORKSPACEPOSSIX%/openssl/ -DAPU_HAVE_CRYPTO=ON -DAPU_HAVE_ODBC=ON ^
 -DAPU_HAVE_OPENSSL=ON -DINSTALL_PDB=ON -DAPR_BUILD_TESTAPR=ON ^
@@ -47,7 +48,7 @@ sha1sum.exe %WORKSPACE%\apr-util-%TAGNAME%-64.zip>%WORKSPACE%\apr-util-%TAGNAME%
 
 IF "%RUN_STATIC_ANALYSIS%" equ "true" (
     REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
-    cppcheck --enable=all --inconclusive --std=c99 ^
+    cppcheck --enable=all --inconclusive --std=c89 ^
     -I%WORKSPACEPOSSIX%/apr/include/ ^
     --output-file=cppcheck.log %WORKSPACEPOSSIX%
 )

--- a/windows/apr/build.bat
+++ b/windows/apr/build.bat
@@ -16,7 +16,8 @@ cd %WORKSPACE%\build-64
 REM Note that some attributes cannot handle backslashes...
 SET WORKSPACEPOSSIX=%WORKSPACE:\=/%
 
-cmake -G "NMake Makefiles" -DAPU_USE_EXPAT=OFF -DAPU_USE_LIBXML2=ON ^
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
+-DAPU_USE_EXPAT=OFF -DAPU_USE_LIBXML2=ON ^
 -DLIBXML2_INCLUDE_DIR=%WORKSPACEPOSSIX%/libxml2/include/libxml2 ^
 -DLIBXML2_LIBRARIES=%WORKSPACEPOSSIX%/libxml2/lib/libxml2.lib;^
 %WORKSPACEPOSSIX%/libxml2/lib/libxml2_a.lib;%WORKSPACEPOSSIX%/libxml2/lib/libxml2_a_dll.lib ^
@@ -49,7 +50,7 @@ sha1sum.exe %WORKSPACE%\apr-%TAGNAME%-64.zip>%WORKSPACE%\apr-%TAGNAME%-64.zip.sh
 
 IF "%RUN_STATIC_ANALYSIS%" equ "true" (
     REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
-    cppcheck --enable=all --inconclusive --std=c99 ^
+    cppcheck --enable=all --inconclusive --std=c89 ^
     -I%WORKSPACEPOSSIX%/libxml2/include/libxml2 ^
     -I%WORKSPACEPOSSIX%/libxml2/include/ ^
     --output-file=cppcheck.log %WORKSPACEPOSSIX%

--- a/windows/bzip2/build.bat
+++ b/windows/bzip2/build.bat
@@ -7,7 +7,8 @@ REM Build environment
 set "PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build;C:\Program Files\Cppcheck;%PATH%"
 call vcvars64
 cd %WORKSPACE%\target\64
-cmake -G "NMake Makefiles" %WORKSPACE%\
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
+%WORKSPACE%\
 nmake
 copy %WORKSPACE%\LICENSE .
 mkdir include
@@ -18,6 +19,6 @@ sha1sum.exe %WORKSPACE%\bzip2-%LUADIST_BZIP2_VERSION%-64.zip>%WORKSPACE%\bzip2-%
 
 IF "%RUN_STATIC_ANALYSIS%" equ "true" (
     REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
-    cppcheck --enable=all --inconclusive --std=c99 ^
+    cppcheck --enable=all --inconclusive --std=c89 ^
     --output-file=cppcheck.log %WORKSPACE%\
 )

--- a/windows/httpd/build.bat
+++ b/windows/httpd/build.bat
@@ -57,7 +57,26 @@ SET "CMAKE_INSTALL_PREFIX_POSSIX=%CMAKE_INSTALL_PREFIX:\=/%"
 cd %WORKSPACE%\cmakebuild
 
 REM CMake. Beware: Command must be shorter than 8191 chars...
-cmake -G "NMake Makefiles" -DOPENSSL_ROOT_DIR=%WORKSPACE_POSSIX%/dependencies/openssl -DLIBXML2_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/libxml2/include/libxml2/ -DLIBXML2_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2.lib;%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2_a.lib;%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2_a_dll.lib -DLIBXML2_XMLLINT_EXECUTABLE=%WORKSPACE_POSSIX%/dependencies/libxml2/bin/xmllint.exe -DLIBXML2_ICONV_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/libxml2/include/ -DLIBXML2_ICONV_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libiconv.lib;%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libcharset.lib -DZLIB_INCLUDE_DIRS=%WORKSPACE_POSSIX%/dependencies/zlib/include/ -DZLIB_LIBRARY=%WORKSPACE_POSSIX%/dependencies/zlib/z.lib -DAPR_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/apr/include/ -DAPR_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/apr/lib/libapr-1.lib;%WORKSPACE_POSSIX%/dependencies/apr/lib/libaprapp-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_crypto_openssl-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_dbd_odbc-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_ldap-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/libaprutil-1.lib -DEXTRA_INCLUDES=%WORKSPACE_POSSIX%/dependencies/apr-util/include/ -DAPU_HAVE_CRYPTO=ON -DAPR_HAS_XLATE=ON -DAPR_HAS_LDAP=ON -DPCRE_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/pcre/lib/bz2.lib;%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcrecppd.lib;%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcred.lib;%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcreposixd.lib -DPCRE_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/pcre/include/ -DLUA_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/lua/lib/lua-v5-3-4.lib;%WORKSPACE_POSSIX%/dependencies/lua/lib/luac.lib -DLUA_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/lua/include/ -DNGHTTP2_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/nghttp2/lib/nghttp2.lib -DNGHTTP2_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/nghttp2/include/ -DCMAKE_INSTALL_PREFIX=%CMAKE_INSTALL_PREFIX_POSSIX% ..
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
+-DOPENSSL_ROOT_DIR=%WORKSPACE_POSSIX%/dependencies/openssl -DLIBXML2_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/libxml2/include/libxml2/ ^
+-DLIBXML2_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2.lib;%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2_a.lib;^
+%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libxml2_a_dll.lib ^
+-DLIBXML2_XMLLINT_EXECUTABLE=%WORKSPACE_POSSIX%/dependencies/libxml2/bin/xmllint.exe ^
+-DLIBXML2_ICONV_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/libxml2/include/ ^
+-DLIBXML2_ICONV_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libiconv.lib;%WORKSPACE_POSSIX%/dependencies/libxml2/lib/libcharset.lib ^
+-DZLIB_INCLUDE_DIRS=%WORKSPACE_POSSIX%/dependencies/zlib/include/ -DZLIB_LIBRARY=%WORKSPACE_POSSIX%/dependencies/zlib/z.lib ^
+-DAPR_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/apr/include/ ^
+-DAPR_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/apr/lib/libapr-1.lib;%WORKSPACE_POSSIX%/dependencies/apr/lib/libaprapp-1.lib;^
+%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_crypto_openssl-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_dbd_odbc-1.lib;^
+%WORKSPACE_POSSIX%/dependencies/apr-util/lib/apr_ldap-1.lib;%WORKSPACE_POSSIX%/dependencies/apr-util/lib/libaprutil-1.lib ^
+-DEXTRA_INCLUDES=%WORKSPACE_POSSIX%/dependencies/apr-util/include/ -DAPU_HAVE_CRYPTO=ON -DAPR_HAS_XLATE=ON -DAPR_HAS_LDAP=ON ^
+-DPCRE_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/pcre/lib/bz2.lib;%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcrecppd.lib;^
+%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcred.lib;%WORKSPACE_POSSIX%/dependencies/pcre/lib/pcreposixd.lib ^
+-DPCRE_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/pcre/include/ -DLUA_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/lua/lib/lua-v5-3-4.lib;^
+%WORKSPACE_POSSIX%/dependencies/lua/lib/luac.lib -DLUA_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/lua/include/ ^
+-DNGHTTP2_LIBRARIES=%WORKSPACE_POSSIX%/dependencies/nghttp2/lib/nghttp2.lib -DNGHTTP2_INCLUDE_DIR=%WORKSPACE_POSSIX%/dependencies/nghttp2/include/ ^
+-DCMAKE_INSTALL_PREFIX=%CMAKE_INSTALL_PREFIX_POSSIX% ..
+
 IF NOT %ERRORLEVEL% == 0 ( exit 1 )
 REM Compile
 nmake

--- a/windows/libexpat/build.bat
+++ b/windows/libexpat/build.bat
@@ -1,0 +1,46 @@
+REM @author: Michal Karm Babacek <karm@fedoraproject.org>
+REM This script builds libexpat
+
+mkdir %WORKSPACE%\target\64
+mkdir %WORKSPACE%\expat\build-64
+
+patch.exe --verbose -p1 CMakeLists.txt -i ci-scripts\windows\libexpat\libexpat-win-CMakeLists.patch
+
+REM Build environment
+set "PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build;C:\Program Files\Cppcheck;%PATH%"
+call vcvars64
+
+cd %WORKSPACE%\expat\build-64
+
+SET WORKSPACEPOSSIX=%WORKSPACE:\=/%
+
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
+-DBUILD_tests=OFF -DBUILD_shared=ON -DCMAKE_INSTALL_PREFIX=%WORKSPACEPOSSIX%/target/64/ ..
+
+nmake
+
+echo "This is not well formed">test.xml
+xmlwf\xmlwf.exe test.xml | findstr /R /C:"syntax error"
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+nmake install
+
+copy %WORKSPACE%\expat\Changes %WORKSPACE%\target\64\
+copy %WORKSPACE%\expat\COPYING %WORKSPACE%\target\64\
+copy %WORKSPACE%\expat\README %WORKSPACE%\target\64\
+
+copy %WORKSPACE%\expat\build-64\*.pdb %WORKSPACE%\target\64\bin\
+
+xcopy %WORKSPACE%\expat\build-64\examples %WORKSPACE%\target\64\examples\ /s /e /h
+
+cd %WORKSPACE%\target\64
+
+zip -r -9 %WORKSPACE%\libexpat-%TAGNAME%-64.zip .
+sha1sum.exe %WORKSPACE%\libexpat-%TAGNAME%-64.zip>%WORKSPACE%\libexpat-%TAGNAME%-64.zip.sha1
+
+IF "%RUN_STATIC_ANALYSIS%" equ "true" (
+    REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
+    cppcheck --enable=all --inconclusive --std=c89 ^
+    -I%WORKSPACEPOSSIX%/include/ ^
+    --output-file=cppcheck.log %WORKSPACEPOSSIX%
+)

--- a/windows/libexpat/libexpat-win-CMakeLists.patch
+++ b/windows/libexpat/libexpat-win-CMakeLists.patch
@@ -1,0 +1,33 @@
+From 3dee0544be824f9ef4da9f7e13b3c7f7367ee193 Mon Sep 17 00:00:00 2001
+From: Michal Karm Babacek <karm@fedoraproject.org>
+Date: Mon, 6 Feb 2017 04:29:30 -0800
+Subject: [PATCH] Win32
+
+---
+ expat/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/expat/CMakeLists.txt b/expat/CMakeLists.txt
+index 349f7aa..633957a 100755
+--- a/expat/CMakeLists.txt
++++ b/expat/CMakeLists.txt
+@@ -93,7 +93,7 @@ install(FILES lib/expat.h lib/expat_external.h DESTINATION include)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/expat.pc DESTINATION lib/pkgconfig)
+
+
+-add_custom_command(TARGET expat PRE_BUILD COMMAND $(MAKE) -C doc xmlwf.1)
++#add_custom_command(TARGET expat PRE_BUILD COMMAND $(MAKE) -C doc xmlwf.1)
+
+ if(BUILD_tools AND NOT WINCE)
+     set(xmlwf_SRCS
+@@ -107,7 +107,7 @@ if(BUILD_tools AND NOT WINCE)
+     set_property(TARGET xmlwf PROPERTY RUNTIME_OUTPUT_DIRECTORY xmlwf)
+     target_link_libraries(xmlwf expat)
+     install(TARGETS xmlwf DESTINATION bin)
+-    install(FILES doc/xmlwf.1 DESTINATION share/man/man1)
++#   install(FILES doc/xmlwf.1 DESTINATION share/man/man1)
+ endif(BUILD_tools AND NOT WINCE)
+
+ if(BUILD_examples)
+--
+2.9.0.windows.1

--- a/windows/mod_proxy_cluster/build.bat
+++ b/windows/mod_proxy_cluster/build.bat
@@ -63,8 +63,7 @@ IF "%DISTRO%" equ "jboss" (
 
 SET HTTPD_DEV_HOME_POSSIX=%HTTPD_DEV_HOME:\=/%
 
-cmake -G "NMake Makefiles" ^
--DCMAKE_BUILD_TYPE=Release ^
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/O2 /Wall /Zi" -DCMAKE_CXX_FLAGS_RELEASE="/O2 /Wall /Zi" ^
 -DAPR_LIBRARY=%HTTPD_DEV_HOME_POSSIX%/lib/libapr-1.lib ^
 -DAPR_INCLUDE_DIR=%HTTPD_DEV_HOME_POSSIX%/include/ ^
 -DAPACHE_INCLUDE_DIR=%HTTPD_DEV_HOME_POSSIX%/include/ ^
@@ -215,7 +214,7 @@ popd
 
 IF "%RUN_STATIC_ANALYSIS%" equ "true" (
     REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
-    cppcheck --enable=all --inconclusive --std=c99 ^
+    cppcheck --enable=all --inconclusive --std=c89 ^
     -I%HTTPD_DEV_HOME_POSSIX%/include/ ^
     -I%WORKSPACE_POSSIX%/mod_proxy_cluster/native/include/ ^
     --output-file=cppcheck.log %WORKSPACE_POSSIX%/mod_proxy_cluster/native/


### PR DESCRIPTION
…etting MSVC flags to /O2 /Wall /Zi

Also I switched cppcheck to c89 because:

```
(03:37:11 PM) karm: jimjag and all,  I've seen https://httpd.apache.org/dev/styleguide.html, yet it leaves me wondering, can I code and compile with C89 ? ANSI?  C99 by any chance?
(03:37:11 PM) karm: I'm mainly interested in current, 2017 contributions to the code; whether it is still important to stick to ANSI or C89...?
(03:39:09 PM) jimjag: Yes, ANSI/C89 is our default. 
(03:39:50 PM) jimjag: You can, of course, compile w/ a newer compiler, but c99 extensions aren't allowed in the actual codebase.
(03:51:31 PM) karm: jimjag: O.K., setting c89 and gonna move all these variable declarations to beginnings of blocks etc... :-( 
```