### PR TITLE
Libiconv is not used ATM, but we build it anyway. Libxml build is wit…

### DIFF
--- a/windows/libiconv/build.bat
+++ b/windows/libiconv/build.bat
@@ -1,0 +1,37 @@
+REM @author: Michal Karm Babacek <karm@fedoraproject.org>
+REM This script builds libiconv from LuaDist https://github.com/LuaDist/
+
+mkdir %WORKSPACE%\target
+mkdir %WORKSPACE%\build
+REM Build environment
+set "PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build;C:\Program Files\Cppcheck;%PATH%"
+call vcvars64
+
+REM Note that some attributes cannot handle backslashes...
+SET WORKSPACEPOSSIX=%WORKSPACE:\=/%
+
+pushd %WORKSPACE%\build
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="/MD /O2 /Ob2 /Wall /Zi" ^
+-DCMAKE_INSTALL_PREFIX=%WORKSPACEPOSSIX%/target/ ..
+nmake
+nmake install
+popd
+
+for /f %%x in ('pushd %WORKSPACE% ^& git log --pretty^=format:%%h -n 1 ^& popd') do set GIT_HEAD=%%x
+echo %GIT_HEAD%
+
+pushd target
+REM Hardcoded libiconv version to remind us of LuaDist's archaic version https://github.com/LuaDist/libiconv
+REM We tried to leave LuaDist libiconv via http://git.savannah.gnu.org/cgit/libiconv.git/tree/README.windows#n57
+REM but failed horribly. It is a pure hell of cygwin-ish, mingw-ish, autotools and MSVC...
+zip -r -9 %WORKSPACE%\libiconv-1.14-%GIT_HEAD%.zip .
+sha1sum.exe %WORKSPACE%\libiconv-1.14-%GIT_HEAD%.zip>%WORKSPACE%\libiconv-1.14-%GIT_HEAD%.zip.sha1
+popd
+
+IF "%RUN_STATIC_ANALYSIS%" equ "true" (
+    REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
+    cppcheck --enable=all --inconclusive --std=c89 ^
+    -I%WORKSPACEPOSSIX%/include/ ^
+    -I%WORKSPACEPOSSIX%/extras/ ^
+    --output-file=cppcheck.log %WORKSPACEPOSSIX%
+)

--- a/windows/libxml2/Makefile.msvc.CRUNTIME.patch
+++ b/windows/libxml2/Makefile.msvc.CRUNTIME.patch
@@ -1,0 +1,33 @@
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 115a451..9da45ec 100644
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -36,14 +36,15 @@ UTILS_INTDIR = int.utils.msvc
+ 
+ # The preprocessor and its options.
+ CPP = cl.exe /EP
+-CPPFLAGS = /nologo /I$(XML_SRCDIR)\include /D "NOLIBTOOL" 
++CPPFLAGS = /nologo /I$(XML_SRCDIR)\include /D "NOLIBTOOL" /MD /O2 /Ob2 /Zi
+ !if "$(WITH_THREADS)" != "no"
+ CPPFLAGS = $(CPPFLAGS) /D "_REENTRANT"
+ !endif
+ 
+ # The compiler and its options.
+ CC = cl.exe
+-CFLAGS = /nologo /D "_WINDOWS" /D "_MBCS" /D "NOLIBTOOL" /W3 /wd4244 /wd4267 $(CRUNTIME)
++CPPFLAGS = $(CPPFLAGS) $(CRUNTIME)
++CFLAGS = /nologo /D "_WINDOWS" /D "_MBCS" /D "NOLIBTOOL" /W3 /wd4244 /wd4267 /MD /O2 /Ob2 /Zi
+ CFLAGS = $(CFLAGS) /I$(XML_SRCDIR) /I$(XML_SRCDIR)\include /I$(INCPREFIX)
+ !if "$(WITH_THREADS)" != "no"
+ CFLAGS = $(CFLAGS) /D "_REENTRANT"
+@@ -101,9 +102,7 @@ ARFLAGS = /nologo
+ CFLAGS = $(CFLAGS) /D "_DEBUG" /Od /Z7
+ LDFLAGS = $(LDFLAGS) /DEBUG
+ !else
+-CFLAGS = $(CFLAGS) /D "NDEBUG" /O2 
+-# commented out as this break VC10 c.f. 634846
+-# LDFLAGS = $(LDFLAGS) /OPT:NOWIN98
++CFLAGS = $(CFLAGS)
+ LDFLAGS = $(LDFLAGS)
+ !endif
+ 

--- a/windows/libxml2/build.bat
+++ b/windows/libxml2/build.bat
@@ -1,0 +1,86 @@
+REM @author: Michal Karm Babacek <karm@fedoraproject.org>
+REM This script builds libxml2
+
+REM unzip label=%label%\libiconv* -d .\libiconv
+REM IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+unzip label=%label%\zlib* -d .\zlib
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+REM Build environment
+set "PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build;C:\Program Files\Cppcheck;%PATH%"
+call vcvars64
+
+REM TODO: For some reason, some? variables from config.msvc are not properly included, hence hard-coded patch.
+C:\Users\Administrator\Tools\cmder\vendor\git-for-windows\usr\bin\patch.exe --verbose -p1 win32\Makefile.msvc -i C:\httpd\ci.modcluster.io\windows\libxml2\Makefile.msvc.CRUNTIME.patch
+
+pushd win32
+
+copy %WORKSPACE%\zlib\include\zlib.h             ..\include\
+copy %WORKSPACE%\zlib\include\zconf.h            ..\include\
+REM copy %WORKSPACE%\libiconv\include\iconv.h        ..\include\
+REM copy %WORKSPACE%\libiconv\include\libcharset.h   ..\include\
+REM copy %WORKSPACE%\libiconv\include\localcharset.h ..\include\
+
+copy %WORKSPACE%\zlib\lib\zlib.lib .
+copy %WORKSPACE%\zlib\bin\zlib.dll .
+REM copy %WORKSPACE%\libiconv\lib\libcharset.lib .
+REM copy %WORKSPACE%\libiconv\bin\libcharset.dll .
+REM copy %WORKSPACE%\libiconv\lib\libiconv.lib iconv.lib
+REM copy %WORKSPACE%\libiconv\bin\libiconv.dll iconv.dll
+REM copy %WORKSPACE%\libiconv\lib\libiconv.lib .
+REM copy %WORKSPACE%\libiconv\bin\libiconv.dll .
+
+REM Note iconv=no; it can be easily set to yes, the script is ready for that, but we don't want to use it. We have APR Iconv.
+cscript configure.js ^
+compiler=msvc ^
+prefix=%WORKSPACE%\target\ ^
+bindir=%WORKSPACE%\target\bin ^
+incdir=%WORKSPACE%\target\include ^
+libdir=%WORKSPACE%\target\lib ^
+sodir=%WORKSPACE%\target\bin ^
+include=%WORKSPACE%\libiconv\include\;%WORKSPACE%\zlib\include\ ^
+lib=%WORKSPACE%\zlib\lib\;%WORKSPACE%\libiconv\lib\ ^
+debug=no ^
+zlib=yes ^
+threads=native ^
+icu=no ^
+iconv=no ^
+cruntime="'/MD /O2 /Ob2 /Zi'"
+
+echo BINPREFIX=%WORKSPACE%\target\bin>>config.msvc
+
+nmake /f Makefile.msvc all
+
+nmake /f Makefile.msvc install
+
+nmake /f Makefile.msvc install-libs
+
+popd
+
+REM set "PATH=%WORKSPACE%\libiconv\bin;%WORKSPACE%\zlib\bin;%PATH%"
+set "PATH=%WORKSPACE%\zlib\bin;%PATH%"
+
+%WORKSPACE%\target\bin\testlimits.exe
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+copy %WORKSPACE%\ChangeLog %WORKSPACE%\target\
+copy %WORKSPACE%\Copyright %WORKSPACE%\target\
+copy %WORKSPACE%\AUTHORS   %WORKSPACE%\target\
+copy %WORKSPACE%\README    %WORKSPACE%\target\
+
+for /f %%x in ('pushd %WORKSPACE% ^& git log --pretty^=format:%%h -n 1 ^& popd') do set GIT_HEAD=%%x
+echo %GIT_HEAD%
+
+pushd %WORKSPACE%\target\
+zip -r -9 %WORKSPACE%\libxml2-%BRANCH_OR_TAG%-%GIT_HEAD%-64.zip .
+sha1sum.exe %WORKSPACE%\libxml2-%BRANCH_OR_TAG%-%GIT_HEAD%-64.zip>%WORKSPACE%\libxml2-%BRANCH_OR_TAG%-%GIT_HEAD%-64.zip.sha1
+popd
+
+SET WORKSPACEPOSSIX=%WORKSPACE:\=/%
+IF "%RUN_STATIC_ANALYSIS%" equ "true" (
+    REM use --force to expand all levels of all macros, kinda slow (single digit minutes even with such a small project)
+    cppcheck --enable=all --inconclusive --std=c89 ^
+    -I%WORKSPACEPOSSIX%/include/ ^
+    -I%WORKSPACEPOSSIX%/zlib/include/ ^
+    --output-file=cppcheck.log %WORKSPACEPOSSIX%
+)


### PR DESCRIPTION
…h zlib, but without libiconv for the time being. httpd will use APR Iconv in place of Libiconv.