### PR TITLE
httpd-dev: Update to version 2.4.68

### DIFF
--- a/httpd-dev/Containerfile
+++ b/httpd-dev/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi:latest
 
-ARG HTTPD_VERSION=2.4.67
+ARG HTTPD_VERSION=2.4.68
 ARG APACHE_DIR=/usr/local/apache2
 
 # install necessary tools (+ some useful ones too)


### PR DESCRIPTION
2.4.68 is out https://github.com/apache/httpd/releases/tag/2.4.68